### PR TITLE
Apply changes to pass shellcheck lints, use the bash interpreter

### DIFF
--- a/install-all.sh
+++ b/install-all.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 SCRIPT_PATH=$(dirname "$(realpath -s "$0")")
-cd "$SCRIPT_PATH"
+cd "$SCRIPT_PATH" || exit
 
 # directory must be of the form "pluginname/"
 for directory in */ ; do
@@ -11,10 +11,10 @@ for directory in */ ; do
         echo "installing $directory"
         # parens required to enter subshell so that each cd starts from here
         if [[ "$1" = "debug" ]]; then
-            (cd "$directory" && cargo build --artifact-dir ~/.local/share/covey/plugins/$directory -Z unstable-options)
+            (cd "$directory" && cargo build --artifact-dir "~/.local/share/covey/plugins/$directory" -Z unstable-options)
         else
-            (cd "$directory" && cargo build --release --artifact-dir ~/.local/share/covey/plugins/$directory -Z unstable-options)
+            (cd "$directory" && cargo build --release --artifact-dir "~/.local/share/covey/plugins/$directory" -Z unstable-options)
         fi
-        cp "$directory/manifest.toml" ~/.local/share/covey/plugins/$directory/manifest.toml
+        cp "$directory/manifest.toml" "~/.local/share/covey/plugins/$directory/manifest.toml"
     fi
 done


### PR DESCRIPTION
```sh
> shellcheck install-all.sh

In install-all.sh line 4:
cd "$SCRIPT_PATH"
^---------------^ SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.

Did you mean:
cd "$SCRIPT_PATH" || exit


In install-all.sh line 10:
    if [[ ! "$directory" =~ "target" ]]; then
       ^-- SC3010 (warning): In POSIX sh, [[ ]] is undefined.


In install-all.sh line 13:
        if [[ "$1" = "debug" ]]; then
           ^------------------^ SC3010 (warning): In POSIX sh, [[ ]] is undefined.


In install-all.sh line 14:
            (cd "$directory" && cargo build --artifact-dir ~/.local/share/covey/plugins/$directory -Z unstable-options)
                                                                                        ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
            (cd "$directory" && cargo build --artifact-dir ~/.local/share/covey/plugins/"$directory" -Z unstable-options)


In install-all.sh line 16:
            (cd "$directory" && cargo build --release --artifact-dir ~/.local/share/covey/plugins/$directory -Z unstable-options)
                                                                                                  ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
            (cd "$directory" && cargo build --release --artifact-dir ~/.local/share/covey/plugins/"$directory" -Z unstable-options)


In install-all.sh line 18:
        cp "$directory/manifest.toml" ~/.local/share/covey/plugins/$directory/manifest.toml
                                                                   ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
        cp "$directory/manifest.toml" ~/.local/share/covey/plugins/"$directory"/manifest.toml

For more information:
  https://www.shellcheck.net/wiki/SC2164 -- Use 'cd ... || exit' or 'cd ... |...
  https://www.shellcheck.net/wiki/SC3010 -- In POSIX sh, [[ ]] is undefined.
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  ```
  As bash-isms are used for comparisons, switch to the bash interpreter which should be installed by default.
  Wrap variable substitutions in quotes
  
  